### PR TITLE
Add resolution and fps options to inpainter

### DIFF
--- a/app/inpaint_api.py
+++ b/app/inpaint_api.py
@@ -1,0 +1,69 @@
+from fastapi import FastAPI, UploadFile, File, Form, HTTPException
+from fastapi.responses import FileResponse
+from diffusers import CogVideoXI2VDualInpaintAnyLPipeline
+from diffusers.utils import load_video, export_to_video
+import torch
+import tempfile
+import os
+
+app = FastAPI()
+
+# Load model once at startup
+pipe = CogVideoXI2VDualInpaintAnyLPipeline.from_pretrained("THUDM/CogVideoX-5b")
+pipe.to("cuda" if torch.cuda.is_available() else "cpu")
+
+@app.post("/inpaint")
+async def inpaint(
+    prompt: str = Form(...),
+    video: UploadFile = File(...),
+    mask: UploadFile = File(...),
+    height: int = Form(720),
+    width: int = Form(1280),
+    output_fps: int = Form(24),
+):
+    """Inpaint a video using CogVideoX pipeline.
+
+    Parameters
+    ----------
+    prompt: str
+        Text prompt to guide inpainting.
+    video: UploadFile
+        Input video file.
+    mask: UploadFile
+        Video mask file where masked regions will be inpainted.
+    height: int
+        Output video height. Defaults to 720.
+    width: int
+        Output video width. Defaults to 1280.
+    output_fps: int
+        Frames per second for exported video. Defaults to 24.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        video_path = os.path.join(tmpdir, video.filename)
+        mask_path = os.path.join(tmpdir, mask.filename)
+        with open(video_path, "wb") as f:
+            f.write(await video.read())
+        with open(mask_path, "wb") as f:
+            f.write(await mask.read())
+
+        frames = load_video(video_path)
+        mask_frames = load_video(mask_path)
+        num_frames = len(frames)
+        if num_frames > 49:
+            raise HTTPException(status_code=400, detail="Video too long (limit 49 frames)")
+
+        result = pipe(
+            prompt=prompt,
+            image=frames[0],
+            video=frames,
+            masks=mask_frames,
+            height=height,
+            width=width,
+            num_frames=num_frames,
+            output_type="np",
+        ).frames[0]
+
+        out_path = os.path.join(tmpdir, "output.mp4")
+        export_to_video(result, out_path, fps=output_fps)
+
+        return FileResponse(out_path, media_type="video/mp4")

--- a/infer/inpaint.py
+++ b/infer/inpaint.py
@@ -224,6 +224,9 @@ def generate_video(
     long_video: bool = False,
     dilate_size: int = -1,
     id_adapter_resample_learnable_path: str = None,
+    output_fps: int = 8,
+    height: int = None,
+    width: int = None,
 ):
     """
     Generates a video based on the given prompt and saves it to the specified path.
@@ -251,6 +254,9 @@ def generate_video(
     - replace_gt (bool): Whether to replace the ground truth.
     - mask_add (bool): Whether to add the mask.
     - down_sample_fps (int): The down sample fps.
+    - output_fps (int): FPS for the exported video.
+    - height (int): Inference height. Defaults to input frame height if None.
+    - width (int): Inference width. Defaults to input frame width if None.
     """
 
     image = None
@@ -435,6 +441,8 @@ def generate_video(
         inpaint_outputs = pipe(
             prompt=prompt,
             image=image,
+            height=height or image.size[1],
+            width=width or image.size[0],
             num_videos_per_prompt=num_videos_per_prompt,
             num_inference_steps=num_inference_steps,
             num_frames=frames,
@@ -455,7 +463,7 @@ def generate_video(
         binary_masks[0] = gt_mask_first_frame
         video[0] = gt_video_first_frame
         round_video = _visualize_video(pipe, mask_background, video[:len(video_generate)], video_generate, binary_masks[:len(video_generate)])
-        export_to_video(round_video, output_path.replace(".mp4", f"_fps{down_sample_fps}.mp4"), fps=8)
+        export_to_video(round_video, output_path.replace(".mp4", f"_fps{down_sample_fps}.mp4"), fps=output_fps)
 
     else:
         raise NotImplementedError
@@ -561,6 +569,24 @@ if __name__ == "__main__":
         help="The dilate size for the mask. Default is -1.",
     )
     parser.add_argument(
+        "--output_fps",
+        type=int,
+        default=8,
+        help="FPS for the saved video. Default is 8.",
+    )
+    parser.add_argument(
+        "--height",
+        type=int,
+        default=None,
+        help="Inference height. Defaults to input video height.",
+    )
+    parser.add_argument(
+        "--width",
+        type=int,
+        default=None,
+        help="Inference width. Defaults to input video width.",
+    )
+    parser.add_argument(
         "--id_adapter_resample_learnable_path",
         type=str,
         default=None,
@@ -598,4 +624,7 @@ if __name__ == "__main__":
         long_video=args.long_video,
         dilate_size=args.dilate_size,
         id_adapter_resample_learnable_path=args.id_adapter_resample_learnable_path,
+        output_fps=args.output_fps,
+        height=args.height,
+        width=args.width,
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,5 @@ safetensors==0.4.3
 huggingface_hub==0.24.1
 av==13.1.0
 gdown
+fastapi==0.111.0
+uvicorn[standard]


### PR DESCRIPTION
## Summary
- expose `height`, `width`, and `output_fps` parameters in `infer/inpaint.py`
- add a FastAPI app `inpaint_api.py` with an `/inpaint` route using the pipeline
- include FastAPI and uvicorn in requirements
- allow the `/inpaint` endpoint to customize output resolution and fps

## Testing
- `python -m py_compile infer/inpaint.py app/inpaint_api.py`

------
https://chatgpt.com/codex/tasks/task_e_688cee4881948330a2a02806038ef231